### PR TITLE
fix: Post /users API의 필요없는 request 값 제거

### DIFF
--- a/src/main/java/sudols/ecopercent/controller/UserController.java
+++ b/src/main/java/sudols/ecopercent/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
     @PostMapping("/users")
     @ResponseBody
     @ResponseStatus(code = HttpStatus.CREATED)
-    public Long CreateUser(@RequestBody UserPostDto userData) {
+    public Long CreateUser(@Valid @RequestBody UserPostDto userData) {
         return userService.join(userData);
     }
 

--- a/src/main/java/sudols/ecopercent/dto/UserPostDto.java
+++ b/src/main/java/sudols/ecopercent/dto/UserPostDto.java
@@ -2,6 +2,7 @@ package sudols.ecopercent.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import sudols.ecopercent.domain.User;
 
@@ -13,8 +14,6 @@ import sudols.ecopercent.domain.User;
 @AllArgsConstructor
 public class UserPostDto {
 
-    private Long userId;
-
     @NotBlank(message = "닉네임은 공백이 아니어야 합니다.")
     private String nickname;
 
@@ -24,21 +23,11 @@ public class UserPostDto {
 
     private String profileImage;
 
-    private String profileMessage;
-
-    private Long titleTumblerId;
-
-    private Long titleEcoBagId;
-
     public User toEntity() {
         return User.builder()
-                .userId(userId)
                 .nickname(nickname)
                 .email(email)
                 .profileImage(profileImage)
-                .profileMessage(profileMessage)
-                .titleTumblerId(titleTumblerId)
-                .titleEcobagId(titleEcoBagId)
                 .build();
     }
 }


### PR DESCRIPTION

ECOPERCENT-211

## 개요
- Post /users API 에서 nickname, email, profile image 외에 제거

## 작업사항
- UserPostDto.java 에서 필요없는 데이터 제거

## 변경로직


## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
